### PR TITLE
fix (test): drop deprecated tap method and match `fastify-cli` templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "author": "David Mark Clements (@davidmarkclem)",
   "license": "MIT",
   "dependencies": {
-    "fastify-cli": "^2.2.0"
+    "fastify-cli": "^2.15.0"
   },
   "devDependencies": {
-    "standard": "^16.0.3",
-    "tap": "^15.0.9"
+    "standard": "^16.0.4",
+    "tap": "^15.1.6"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -6,11 +6,12 @@ const { mkdtempSync, readdirSync } = require('fs')
 const { tmpdir } = require('os')
 const { spawnSync } = require('child_process')
 
-test('generates a fastify project in the current folder', async ({ same, is }) => {
+test('generates a fastify project in the current folder', async ({ equal, match }) => {
   const dir = mkdtempSync(join(tmpdir(), 'create-fastify-test'))
   spawnSync('node', [join(__dirname, 'cmd.js')], { cwd: dir })
-  same(readdirSync(dir).sort(), [
+  match(readdirSync(dir).sort(), [
     '.gitignore',
+    '.vscode',
     'README.md',
     'app.js',
     'package.json',
@@ -19,5 +20,5 @@ test('generates a fastify project in the current folder', async ({ same, is }) =
     'test'
   ])
   const { name } = require(join(dir, 'package.json'))
-  is(name.toLowerCase(), basename(dir).toLowerCase())
+  equal(name.toLowerCase(), basename(dir).toLowerCase())
 })


### PR DESCRIPTION
Hello.

This PR aims to :
- upgrade package dependencies
- fix failing tests since https://github.com/fastify/fastify-cli/pull/427 adding a `.vscode` directory to `fastify-cli`'s templates
- drop deprecated `tap` methods

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
