### PR TITLE
chore: add mention of @fastify/autoload in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,8 @@ Files and folders that will be overwritten by integrate mode:
 
 The `package.json` file will not be overwritten but will be modified.
 
+The plugins are loaded with [@fastify/autoload](https://github.com/fastify/fastify-autoload) with an empty default configuration.
+
 ## Contributing
 If you feel you can help in any way, be it with examples, extra testing, or new features please open a pull request or open an issue.
 


### PR DESCRIPTION
Fix for https://github.com/fastify/help/issues/760

The discussion stemmed from an [SO answer](https://stackoverflow.com/questions/73816687/nested-route-gives-404-not-found-on-a-fastify-app-with-file-based-routing) which was erroneous, suggesting `@fastify/autoload` maxDepth's defaults to 2 when it does not.
The conversation hinted at `create-fastify` not having sufficient information that it is using autoload with default options, which this PR resolves.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
