### PR TITLE
feat: added ability to specify project name

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-const args = process.argv.slice(2)
+const args = [...process.argv.slice(2)]
 
 if (!args[0] || args[0].startsWith('-')) {
   args.unshift('.')

--- a/cmd.js
+++ b/cmd.js
@@ -2,4 +2,10 @@
 
 'use strict'
 
-require('fastify-cli/generate').cli(['.', ...process.argv.slice(2)])
+const args = process.argv.slice(2)
+
+if (!args[0] || args[0].startsWith('-')) {
+  args.unshift('.')
+}
+
+require('fastify-cli/generate').cli(args)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 There is no need to install this package directly.
 
 ```sh
-npm init fastify
+npm init fastify [yourapp]
 ```
 
 The `npm init` command will find this package automatically and run it.

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@
 There is no need to install this package directly.
 
 ```sh
-npm init fastify [yourapp]
+npm init fastify [your_app_name]
 ```
 
 The `npm init` command will find this package automatically and run it.

--- a/test.js
+++ b/test.js
@@ -41,9 +41,14 @@ test('generates a fastify project in the current folder using --integrate', asyn
   const projectName = 'create-fastify-test-integrate'
   const dir = join(testDir, projectName)
   mkdirSync(dir)
+  const { stdout: npmVersion } = spawnSync('npm', ['--version'], { cwd: dir })
   spawnSync('npm', ['init', '-y'], { cwd: dir })
   spawnSync('npm', ['link', 'create-fastify'], { cwd: dir })
-  spawnSync('npm', ['init', 'fastify', '--', '--integrate'], { cwd: dir })
+  if (parseInt(npmVersion.toString().split('.')[0], 10) < 7) {
+    spawnSync('npm', ['init', 'fastify', '--integrate'], { cwd: dir })
+  } else {
+    spawnSync('npm', ['init', 'fastify', '--', '--integrate'], { cwd: dir })
+  }
   t.match(readdirSync(dir).sort(), [
     '.gitignore',
     'README.md',

--- a/test.js
+++ b/test.js
@@ -1,26 +1,30 @@
 'use strict'
 
-const { test, teardown } = require('tap')
+const { test, teardown, before } = require('tap')
 const { join } = require('node:path')
 const { mkdtempSync, readdirSync, mkdirSync, rmSync } = require('node:fs')
 const { tmpdir } = require('node:os')
 const { spawnSync } = require('node:child_process')
 
 const testDir = mkdtempSync(join(tmpdir(), 'create-fastify-test-'))
-spawnSync('npm', ['link'], { cwd: __dirname })
+
+before(() => {
+  spawnSync('npm', ['link'], { cwd: __dirname, shell: true })
+})
 
 teardown(() => {
-  spawnSync('npm', ['unlink'], { cwd: __dirname })
+  spawnSync('npm', ['unlink', '-g'], { cwd: __dirname, shell: true })
   rmSync(testDir, { recursive: true, force: true })
 })
 
-test('generates a fastify project in the current folder', async (t) => {
+test('generates a fastify project in the current folder', (t) => {
   t.plan(3)
   const projectName = 'create-fastify-test-current'
   const dir = join(testDir, projectName)
+  const opts = { cwd: dir, shell: true }
   mkdirSync(dir)
-  spawnSync('npm', ['link', 'create-fastify'], { cwd: dir })
-  spawnSync('npm', ['init', 'fastify'], { cwd: dir })
+  spawnSync('npm', ['link', 'create-fastify'], opts)
+  spawnSync('npm', ['init', 'fastify'], opts)
   t.match(readdirSync(dir).sort(), [
     '.gitignore',
     'README.md',
@@ -36,18 +40,19 @@ test('generates a fastify project in the current folder', async (t) => {
   t.equal(name, projectName)
 })
 
-test('generates a fastify project in the current folder using --integrate', async (t) => {
+test('generates a fastify project in the current folder using --integrate', (t) => {
   t.plan(3)
   const projectName = 'create-fastify-test-integrate'
   const dir = join(testDir, projectName)
+  const opts = { cwd: dir, shell: true }
   mkdirSync(dir)
-  const { stdout: npmVersion } = spawnSync('npm', ['--version'], { cwd: dir })
-  spawnSync('npm', ['init', '-y'], { cwd: dir })
-  spawnSync('npm', ['link', 'create-fastify'], { cwd: dir })
+  const { stdout: npmVersion } = spawnSync('npm', ['--version'], opts)
+  spawnSync('npm', ['init', '-y'], opts)
+  spawnSync('npm', ['link', 'create-fastify'], opts)
   if (parseInt(npmVersion.toString().split('.')[0], 10) < 7) {
-    spawnSync('npm', ['init', 'fastify', '--integrate'], { cwd: dir })
+    spawnSync('npm', ['init', 'fastify', '--integrate'], opts)
   } else {
-    spawnSync('npm', ['init', 'fastify', '--', '--integrate'], { cwd: dir })
+    spawnSync('npm', ['init', 'fastify', '--', '--integrate'], opts)
   }
   t.match(readdirSync(dir).sort(), [
     '.gitignore',
@@ -64,12 +69,13 @@ test('generates a fastify project in the current folder using --integrate', asyn
   t.equal(name, projectName)
 })
 
-test('generates a fastify project in a new folder', async (t) => {
+test('generates a fastify project in a new folder', (t) => {
   t.plan(3)
   const projectName = 'create-fastify-new-dir'
   const dir = join(testDir, projectName)
-  spawnSync('npm', ['link', 'create-fastify'], { cwd: testDir })
-  spawnSync('npm', ['init', 'fastify', projectName], { cwd: testDir })
+  const opts = { cwd: testDir, shell: true }
+  spawnSync('npm', ['link', 'create-fastify'], opts)
+  spawnSync('npm', ['init', 'fastify', projectName], opts)
   t.match(readdirSync(dir).sort(), [
     '.gitignore',
     'README.md',

--- a/test.js
+++ b/test.js
@@ -1,15 +1,71 @@
 'use strict'
 
-const { test } = require('tap')
-const { join, basename } = require('node:path')
-const { mkdtempSync, readdirSync } = require('node:fs')
+const { test, teardown } = require('tap')
+const { join } = require('node:path')
+const { mkdtempSync, readdirSync, mkdirSync, rmSync } = require('node:fs')
 const { tmpdir } = require('node:os')
 const { spawnSync } = require('node:child_process')
 
-test('generates a fastify project in the current folder', async ({ equal, match }) => {
-  const dir = mkdtempSync(join(tmpdir(), 'create-fastify-test'))
-  spawnSync('node', [join(__dirname, 'cmd.js')], { cwd: dir })
-  match(readdirSync(dir).sort(), [
+const testDir = mkdtempSync(join(tmpdir(), 'create-fastify-test-'))
+spawnSync('npm', ['link'], { cwd: __dirname })
+
+teardown(() => {
+  spawnSync('npm', ['unlink'], { cwd: __dirname })
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+test('generates a fastify project in the current folder', async (t) => {
+  t.plan(3)
+  const projectName = 'create-fastify-test-current'
+  const dir = join(testDir, projectName)
+  mkdirSync(dir)
+  spawnSync('npm', ['link', 'create-fastify'], { cwd: dir })
+  spawnSync('npm', ['init', 'fastify'], { cwd: dir })
+  t.match(readdirSync(dir).sort(), [
+    '.gitignore',
+    'README.md',
+    'app.js',
+    'node_modules', // added by npm link
+    'package.json',
+    'plugins',
+    'routes',
+    'test'
+  ])
+  const { name, dependencies } = require(join(dir, 'package.json'))
+  t.ok(Object.keys(dependencies).includes('fastify'))
+  t.equal(name, projectName)
+})
+
+test('generates a fastify project in the current folder using --integrate', async (t) => {
+  t.plan(3)
+  const projectName = 'create-fastify-test-integrate'
+  const dir = join(testDir, projectName)
+  mkdirSync(dir)
+  spawnSync('npm', ['init', '-y'], { cwd: dir })
+  spawnSync('npm', ['link', 'create-fastify'], { cwd: dir })
+  spawnSync('npm', ['init', 'fastify', '--', '--integrate'], { cwd: dir })
+  t.match(readdirSync(dir).sort(), [
+    '.gitignore',
+    'README.md',
+    'app.js',
+    'node_modules', // added by npm link
+    'package.json',
+    'plugins',
+    'routes',
+    'test'
+  ])
+  const { name, dependencies } = require(join(dir, 'package.json'))
+  t.ok(Object.keys(dependencies).includes('fastify'))
+  t.equal(name, projectName)
+})
+
+test('generates a fastify project in a new folder', async (t) => {
+  t.plan(3)
+  const projectName = 'create-fastify-new-dir'
+  const dir = join(testDir, projectName)
+  spawnSync('npm', ['link', 'create-fastify'], { cwd: testDir })
+  spawnSync('npm', ['init', 'fastify', projectName], { cwd: testDir })
+  t.match(readdirSync(dir).sort(), [
     '.gitignore',
     'README.md',
     'app.js',
@@ -18,6 +74,7 @@ test('generates a fastify project in the current folder', async ({ equal, match 
     'routes',
     'test'
   ])
-  const { name } = require(join(dir, 'package.json'))
-  equal(name.toLowerCase(), basename(dir).toLowerCase())
+  const { name, dependencies } = require(join(dir, 'package.json'))
+  t.ok(Object.keys(dependencies).includes('fastify'))
+  t.equal(name, projectName)
 })


### PR DESCRIPTION
Optionally specify the directory to `fastify generate`

I also updated the test suite to use `npm link` so that the tests can be run as `npm init fastify`, so issues like #3 can be caught here.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
