### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fastify-cli": "^7.0.0"
   },
   "devDependencies": {
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0"
   },
   "repository": {


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.